### PR TITLE
Add support for waitForElement

### DIFF
--- a/src/ReactTestingLibrary.re
+++ b/src/ReactTestingLibrary.re
@@ -55,3 +55,5 @@ let render = (~baseElement=?, ~container=?, element) => {
 };
 
 let debug = (~el=?, ()) => _debug(Js.Undefined.fromOption(el));
+
+let waitForElement = DomTestingLibrary.waitForElement;

--- a/src/ReactTestingLibrary.rei
+++ b/src/ReactTestingLibrary.rei
@@ -49,3 +49,7 @@ let render:
   renderResult;
 
 let debug: (~el: Dom.element=?, unit, renderResult) => unit;
+
+let waitForElement:
+  (~callback: unit => 'a=?, ~options: DomTestingLibrary.WaitForElement.options=?, unit) =>
+    Js.Promise.t('a);


### PR DESCRIPTION
The [waitForElement](https://testing-library.com/docs/api-async#waitforelement) API had exported in `DomTestingLibrary` interface, this PR just re-exported the same API.

![screenshot_2019-03-19 22-05-24](https://user-images.githubusercontent.com/87983/54612079-2d2bbd80-4a93-11e9-915b-e01d9b74c3f3.jpg)
