### PR TITLE
Fix queries so they are bound to baseElement

### DIFF
--- a/src/ReactTestingLibrary.re
+++ b/src/ReactTestingLibrary.re
@@ -30,23 +30,23 @@ external _debug : Js.undefined(Dom.element) => unit = "debug";
 external rerender : ReasonReact.reactElement => unit = "";
 
 let getByAltText = (string, result) =>
-  getByAltText(string, result |> container);
+  getByAltText(string, result |> baseElement);
 
 let getByPlaceholderText = (string, result) =>
-  getByPlaceholderText(string, result |> container);
+  getByPlaceholderText(string, result |> baseElement);
 
 let getByTestId = (string, result) =>
-  getByTestId(string, result |> container);
+  getByTestId(string, result |> baseElement);
 
 let getByText = (~matcher, ~options=?, result) =>
-  getByText(~matcher, ~options=?options, result |> container);
+  getByText(~matcher, ~options=?options, result |> baseElement);
 
 let getByLabelText = (~matcher, ~options=?, result) =>
-  getByLabelText(~matcher, ~options=?options, result |> container);
+  getByLabelText(~matcher, ~options=?options, result |> baseElement);
 
-let getByTitle = (string, result) => getByTitle(string, result |> container);
+let getByTitle = (string, result) => getByTitle(string, result |> baseElement);
 
-let getByDisplayValue = (string, result) => getByDisplayValue(string, result |> container);
+let getByDisplayValue = (string, result) => getByDisplayValue(string, result |> baseElement);
 
 let render = (~baseElement=?, ~container=?, element) => {
   let baseElement_ =

--- a/src/__tests__/ReactTestingLibrary_test.re
+++ b/src/__tests__/ReactTestingLibrary_test.re
@@ -39,6 +39,10 @@ describe("ReactTestingLibrary", () => {
     </div>
   );
 
+  afterEach(() => {
+    cleanup();
+  });
+
   test("render works", () => {
     element
       |> render


### PR DESCRIPTION
**Issue**
Queries are not bound to `baseElement`

From the [docs](https://testing-library.com/docs/react-testing-library/api):
> Note: the queries returned by the render looks into baseElement, so you can use queries to test your portal component without the `baseElement`.

By looking at the [code](https://github.com/wyze/bs-react-testing-library/blob/8f34840eae3dc1b0cedccecca6a1d41a1d946053/src/ReactTestingLibrary.re#L42) this is not the case within `bs-react-testing-library`

This PR addresses that.