### PR TITLE
Change type of cleanup function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,6 @@ jobs:
           deno-version: '0.40'
       - run: yarn install --frozen-lockfile
       - run: yarn --check-files
-      - run: deno run --allow-read --allow-write https://denopkg.com/wyze/conditional_bisect@v1.0.0/mod.ts
+      - run: deno run --allow-read --allow-write https://denopkg.com/wyze/conditional_bisect@v1.0.1/mod.ts
       - run: yarn test:coverage
       - run: yarn bisect-ppx-report send-to Codecov

--- a/src/ReactTestingLibrary.re
+++ b/src/ReactTestingLibrary.re
@@ -16,7 +16,7 @@ type renderOptions = {
 };
 
 [@bs.module "@testing-library/react"]
-external cleanup: unit => unit = "cleanup";
+external cleanup: unit => Js.Promise.t(unit) = "cleanup";
 
 [@bs.module "@testing-library/react"]
 external _act: (unit => Js.undefined(Js.Promise.t('a))) => unit = "act";

--- a/src/ReactTestingLibrary.rei
+++ b/src/ReactTestingLibrary.rei
@@ -84,7 +84,7 @@ type renderOptions = {
 };
 
 [@bs.module "@testing-library/react"]
-external cleanup: unit => unit = "cleanup";
+external cleanup: unit => Js.Promise.t(unit) = "cleanup";
 
 let act: (unit => unit) => unit;
 

--- a/src/__tests__/ReactTestingLibrary_test.re
+++ b/src/__tests__/ReactTestingLibrary_test.re
@@ -16,14 +16,15 @@ module Counter = {
 
   [@react.component]
   let make = () => {
-    let (state, dispatch) = React.useReducer(
-      (state, action) =>
-        switch (action) {
-        | Inc => state + 1
-        | Dec => state - 1
-        },
-      0
-    );
+    let (state, dispatch) =
+      React.useReducer(
+        (state, action) =>
+          switch (action) {
+          | Inc => state + 1
+          | Dec => state - 1
+          },
+        0,
+      );
 
     <div>
       {ReasonReact.string("Count: " ++ string_of_int(state))}
@@ -33,7 +34,7 @@ module Counter = {
       <button onClick={_event => dispatch(Dec)}>
         {ReasonReact.string("-")}
       </button>
-    </div>
+    </div>;
   };
 };
 
@@ -684,5 +685,21 @@ describe("ReactTestingLibrary", () => {
     |> getByText(~matcher=`Str("Count: 1"))
     |> expect
     |> toMatchSnapshot;
+  });
+
+  testPromise("Cleaunp, (element not found)", () => {
+    let result = element |> render;
+
+    cleanup()
+    |> Js.Promise.(
+         then_(_ => {
+           Js.Promise.resolve(
+             result
+             |> queryByTestId(~matcher=`Str("h1-heading"))
+             |> expect
+             |> toMatchSnapshot,
+           )
+         })
+       );
   });
 });

--- a/src/__tests__/__snapshots__/ReactTestingLibrary_test.bs.js.snap
+++ b/src/__tests__/__snapshots__/ReactTestingLibrary_test.bs.js.snap
@@ -400,6 +400,8 @@ exports[`ReactTestingLibrary ByTitle queryByTitle works 1`] = `
 />
 `;
 
+exports[`ReactTestingLibrary Cleaunp, (element not found) 1`] = `null`;
+
 exports[`ReactTestingLibrary act works 1`] = `
 <div>
   Count: 1


### PR DESCRIPTION
Return type for `cleanup` function changed to `Js.Promise.t(unit)` according to source:
https://github.com/testing-library/react-testing-library/blob/6833b8a0a78817782a0c4df3d8e33271c688e93e/src/pure.js#L99