### PR TITLE
Remove ReasonReact.reactElement for React.element

### DIFF
--- a/src/ReactTestingLibrary.re
+++ b/src/ReactTestingLibrary.re
@@ -30,7 +30,7 @@ let act = callback =>
   });
 
 [@bs.module "@testing-library/react"]
-external _render: (ReasonReact.reactElement, renderOptions) => renderResult =
+external _render: (React.element, renderOptions) => renderResult =
   "render";
 
 [@bs.get] external container: renderResult => Dom.element = "container";
@@ -44,7 +44,7 @@ external _debug: (Js.undefined(Dom.element), Js.undefined(int)) => unit =
 [@bs.send.pipe: renderResult] external unmount: unit => bool = "unmount";
 
 [@bs.send.pipe: renderResult]
-external rerender: ReasonReact.reactElement => unit = "rerender";
+external rerender: React.element => unit = "rerender";
 
 [@bs.send.pipe: renderResult]
 external asFragment: unit => Dom.element = "asFragment";


### PR DESCRIPTION
While this lib has been used internally at @ahrefs, and we would like to have it updated even thought hasn't been any change for a long time and don't want to fork and keep those changes internally.

We are updating reason-react to 0.11 and one of the breaking changes is the deprecation of ReasonReact module.

EDIT: I just saw the lack of maintainability on this lib and the migration to ReScript. I will keep those changes in a separate package.